### PR TITLE
Don't break the transfer loop

### DIFF
--- a/Mods/TakeAll/Scripts/TakeAllModManager.cs
+++ b/Mods/TakeAll/Scripts/TakeAllModManager.cs
@@ -186,11 +186,6 @@ namespace TakeAll
                         {
                             TransferItemToPlayer(item, itemCollection);
                         }
-                        else
-                        {
-                            DisplayTakeAllFailedToTakeEverythingWindow();
-                            break;
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Currently, the script iterates through the items until it finds one that is too heavy for the player to hold, and then stops. The problem with this is that any following items that are small enough to fit in the player's inventory are not transferred.

I suggest removing the else block altogether. I find the message popup that comes with it a bit annoying anyway. The popup could be implemented without breaking the loop if necessary.